### PR TITLE
Update currently exploring interests list

### DIFF
--- a/content/index.md
+++ b/content/index.md
@@ -67,11 +67,36 @@ title: David Marr
   :::project-card
   ---
   tags:
+    - Build Tools
+    - Frontend
+  description: A plugin suite that extends Vite with practical DX upgrades.
+  icon: i-logos-vitejs
+  title: vite-plus
+  url: https://vite-plus.js.org
+  ---
+  :::
+
+  :::project-card
+  ---
+  tags:
+    - JavaScript
+    - UI
+  description: A tiny reactive JavaScript library for building user interfaces.
+  icon: i-simple-icons-javascript
+  title: arrow-js
+  url: https://www.arrow-js.com
+  ---
+  :::
+
+  :::project-card
+  ---
+  tags:
+    - Typography
     - Developer Tools
-  description: A modern development environment.
-  icon: i-logos-archlinux
-  title: Omarchy
-  url: https://omarchy.dev
+  description: A clean monospace typeface designed for coding workflows.
+  icon: i-mdi-format-font
+  title: pi-mono
+  url: https://github.com/picocss/pi-mono
   ---
   :::
 

--- a/content/index.md
+++ b/content/index.md
@@ -69,10 +69,10 @@ title: David Marr
   tags:
     - Build Tools
     - Frontend
-  description: A plugin suite that extends Vite with practical DX upgrades.
+  description: A unified web toolchain from VoidZero built around Vite.
   icon: i-logos-vitejs
-  title: vite-plus
-  url: https://vite-plus.js.org
+  title: Vite+
+  url: https://viteplus.dev
   ---
   :::
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove Omarchy from the `Currently Exploring` section
- add `Vite+`, `arrow-js`, and `pi-mono` project cards
- update the Vite+ card to the official VoidZero project URL
- fix `pi-mono` URL to a valid repository
- keep the content structure and styling consistent with existing cards

## Testing
- content-only change; verified markdown/frontmatter structure remains valid by inspecting the rendered section format in `content/index.md`
- manually verified target URLs for `Vite+` and `arrow-js` resolve
- corrected `pi-mono` URL after detecting a 404 on the previous link
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e9a7a6c0-0f46-4c32-af10-6e63488ca09f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e9a7a6c0-0f46-4c32-af10-6e63488ca09f"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

