### PR TITLE
fix: mount Arrow streaming chart reliably in ClientOnly

### DIFF
--- a/app/components/SiteHeader.vue
+++ b/app/components/SiteHeader.vue
@@ -20,6 +20,12 @@ const items = computed(() => [
     icon: "i-mdi-book-open-page-variant",
     active: route.path.startsWith("/blog"),
   },
+  {
+    label: "Streaming",
+    to: "/streaming-chart",
+    icon: "i-mdi-chart-line",
+    active: route.path.startsWith("/streaming-chart"),
+  },
 ]);
 </script>
 

--- a/app/pages/streaming-chart.vue
+++ b/app/pages/streaming-chart.vue
@@ -100,6 +100,8 @@ const resetSeries = () => {
 };
 
 let intervalHandle: ReturnType<typeof setInterval> | undefined;
+let stopWatchingMount: (() => void) | undefined;
+let appMounted = false;
 
 const restartInterval = () => {
   if (intervalHandle) clearInterval(intervalHandle);
@@ -108,12 +110,8 @@ const restartInterval = () => {
   }, state.tickMs);
 };
 
-onMounted(() => {
-  resetSeries();
-  restartInterval();
-
-  if (!mountEl.value) return;
-
+const mountArrowApp = () => {
+  if (!mountEl.value || appMounted) return;
   const app = html`
     <section class="space-y-6">
       <div class="grid gap-4 md:grid-cols-4">
@@ -237,10 +235,28 @@ onMounted(() => {
 
   mountEl.value.replaceChildren();
   app(mountEl.value);
+  appMounted = true;
+};
+
+onMounted(() => {
+  resetSeries();
+  restartInterval();
+
+  stopWatchingMount = watch(
+    mountEl,
+    (el) => {
+      if (!el) return;
+      mountArrowApp();
+      stopWatchingMount?.();
+      stopWatchingMount = undefined;
+    },
+    { immediate: true, flush: "post" },
+  );
 });
 
 onBeforeUnmount(() => {
   if (intervalHandle) clearInterval(intervalHandle);
+  stopWatchingMount?.();
 });
 </script>
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix the `/streaming-chart` Arrow.js mount lifecycle by waiting for the `ref` container to exist before mounting
- add a `Streaming` nav link in the site header to ensure route discoverability and crawler reachability for static prerender

## Context
The previous PR introducing the streaming chart was merged before this fix commit, so production/main is missing this patch.

## Verification
- `npx nuxi build --preset github_pages` passes
- prerender output includes `/streaming-chart`
- static output contains `.output/public/streaming-chart`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://graphstrike.slack.com/archives/D0ANE9MQ9EG/p1774301422592489?thread_ts=1774301422.592489&cid=D0ANE9MQ9EG)

<div><a href="https://cursor.com/agents/bc-3642908b-9387-5c5c-95cc-ef929c2ca496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-3642908b-9387-5c5c-95cc-ef929c2ca496"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

