### PR TITLE
fix(streaming): correct Arrow.js viewBox template binding

### DIFF
--- a/app/pages/streaming-chart.vue
+++ b/app/pages/streaming-chart.vue
@@ -135,7 +135,7 @@ const mountArrowApp = () => {
 
       <div class="overflow-hidden rounded-xl border border-default bg-elevated">
         <svg
-          viewBox="0 0 ${viewport.width} ${viewport.height}"
+          viewBox="${`0 0 ${viewport.width} ${viewport.height}`}"
           class="h-72 w-full"
           role="img"
           aria-label="Streaming line chart"


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- fix the streaming chart Arrow template to bind `viewBox` as a single expression
- avoid mixed static + multiple interpolation segments in one attribute, which can break Arrow template parsing/runtime binding

## Validation
- `pnpm build` succeeds
- `pnpm generate` succeeds
- dev route fetch for `/streaming-chart` returns successfully
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://graphstrike.slack.com/archives/D0ANE9MQ9EG/p1774305048610439?thread_ts=1774305048.610439&cid=D0ANE9MQ9EG)

<div><a href="https://cursor.com/agents/bc-def5525d-bb12-5701-9f03-8c326f0509d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-def5525d-bb12-5701-9f03-8c326f0509d0"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

