### PR TITLE
Homepage: heerich + AI & taste link section

### DIFF
--- a/.impeccable.md
+++ b/.impeccable.md
@@ -47,3 +47,5 @@ Suggested **information architecture** (see `content/index.md`):
 | **Archive** | Demos or tools you no longer foreground; kept for reference. |
 
 Keep descriptions factual and short; avoid hype. Rebalance cards between **Exploring** and **Archive** as interests change.
+
+The **AI & taste** block at the bottom of the home page (`::ai-skills-section` in `content/index.md`) is a link list, not a card grid—lighter hierarchy so it reads as references, not product picks.

--- a/app/components/content/AiSkillsSection.vue
+++ b/app/components/content/AiSkillsSection.vue
@@ -1,0 +1,59 @@
+<template>
+  <section class="pt-10 mt-4 border-t border-default/20">
+    <header
+      v-if="title || description"
+      class="mb-6 max-w-prose border-l-2 border-primary/25 pl-4"
+    >
+      <h2
+        v-if="title"
+        class="text-xl font-semibold tracking-tight text-default"
+      >
+        {{ title }}
+      </h2>
+      <p
+        v-if="description"
+        class="mt-2 text-sm leading-relaxed text-muted"
+      >
+        {{ description }}
+      </p>
+    </header>
+    <ul class="space-y-3 max-w-prose">
+      <li
+        v-for="(item, i) in items"
+        :key="i"
+        class="text-sm leading-relaxed"
+      >
+        <ULink
+          :to="item.url"
+          target="_blank"
+          class="font-medium text-default hover:text-primary transition-colors"
+        >
+          {{ item.label }}
+        </ULink>
+        <span
+          v-if="item.hint"
+          class="text-muted"
+        >
+          — {{ item.hint }}
+        </span>
+      </li>
+    </ul>
+  </section>
+</template>
+
+<script setup lang="ts">
+interface LinkItem {
+  label: string
+  url: string
+  /** Short gloss after the link (em dash in template). */
+  hint?: string
+}
+
+interface Props {
+  title?: string
+  description?: string
+  items: LinkItem[]
+}
+
+defineProps<Props>()
+</script>

--- a/content/index.md
+++ b/content/index.md
@@ -202,6 +202,18 @@ description: On the workbench right now—frameworks, infra, and ideas worth try
   :::project-card
   ---
   tags:
+    - 3D
+    - SVG
+  description: Tiny engine for 3D voxel scenes rendered to SVG—boolean ops, oblique and perspective cams, zero dependencies.
+  icon: i-mdi-cube-outline
+  title: heerich
+  url: https://github.com/meodai/heerich
+  ---
+  :::
+
+  :::project-card
+  ---
+  tags:
     - React
     - Full‑stack
   description: The next generation of full-stack web applications.
@@ -287,4 +299,24 @@ description: Older demos and experiments—still here for reference, not the mai
   url: https://claytonfarr.github.io/ralph-playbook/
   ---
   :::
+::
+
+::ai-skills-section
+---
+title: AI & taste
+description: Resources I reach for when steering agents and UIs—separate from the product stack list above.
+items:
+  - label: Impeccable
+    url: https://impeccable.style
+    hint: Design guidance for “good taste” in AI UIs
+  - label: Agents with taste
+    url: https://emilkowal.ski/ui/agents-with-taste
+    hint: Emil Kowalski on high-agency, detail-led interfaces
+  - label: Interface details
+    url: https://jakub.kr/writing/details-that-make-interfaces-feel-better
+    hint: Jakub Krośniak on micro-interactions and polish
+  - label: compound-engineering (Cursor plugin)
+    url: https://github.com/EveryInc/compound-engineering-plugin
+    hint: Workflow patterns in the editor
+---
 ::


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- **Exploring:** Adds [heerich](https://github.com/meodai/heerich)—3D voxel scenes to SVG (repo README copy), with `i-mdi-cube-outline`.
- **After Archive:** New **`AiSkillsSection`** content component (not a second project grid): titled **“AI & taste”** with a short intro and a compact link list for [impeccable.style](https://impeccable.style), [Agents with taste](https://emilkowal.ski/ui/agents-with-taste), [Interface details](https://jakub.kr/writing/details-that-make-interfaces-feel-better), and [compound-engineering-plugin](https://github.com/EveryInc/compound-engineering-plugin). Edit links in `content/index.md` frontmatter.
- **`.impeccable.md`:** one line documenting that the AI block is intentionally lighter than the card grids.

`pnpm build` and `nuxi typecheck` pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-bfe7ee52-874b-4339-88de-741bdb3c7b4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-bfe7ee52-874b-4339-88de-741bdb3c7b4a"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

