### PR TITLE
Blog: document Flux Operator / FluxInstance instead of flux bootstrap

### DIFF
--- a/content/blog/homelab-flux-gitops-journey.md
+++ b/content/blog/homelab-flux-gitops-journey.md
@@ -13,7 +13,7 @@ Here's what I built, what broke, and how I'll do it again.
 ## The Stack
 
 - **Talos Linux** — Immutable, API-driven Kubernetes. No SSH, no shell, no apt-get. Sounds limiting until you realize you never need to debug "what changed on the node."
-- **Flux** — GitOps controller. Everything lives in a git repo, Flux reconciles it to the cluster. Push a change, it lands. Revert a change, it's gone.
+- **Flux** — GitOps via the **Flux Operator**: a `FluxInstance` CR installs controllers and points **sync** at your Git (or OCI) path. Everything still lives in git; push a change, it lands. Revert, it's gone.
 - **SOPS + Age** — Encrypted secrets in git. No plaintext, no sealed-secrets complexity. Decrypt with your age key, apply, done.
 - **Homepage** — Dashboard with widgets for every service. Internal URLs, API tokens, done.
 - **Traefik** — Ingress with ACME DNS challenges for `*.example.com` certs.
@@ -163,8 +163,8 @@ The workflow is muscle memory now:
 # Commit and push
 git add -A && git commit -m "feat: add thing" && git push
 
-# Reconcile
-flux reconcile kustomization apps --with-source
+# Reconcile (namespace matches where your Kustomization lives, often flux-system)
+flux reconcile kustomization apps -n flux-system --with-source
 
 # Verify
 kubectl get helmrelease -A
@@ -258,24 +258,51 @@ If you want to try this yourself:
 - A git repo for your Flux configuration
 - Time to break things
 
-### 2. Bootstrap Flux
+### 2. Install Flux with the Flux Operator
 
-Follow the [official Flux getting started guide](https://fluxcd.io/flux/get-started/) to install Flux on your cluster, then bootstrap your GitOps repository:
+The maintained install path is the **Flux Operator**: it owns controller upgrades, wiring, and the **Flux Web UI** knobs you enable on `FluxInstance`. You apply one **`FluxInstance`** named `flux` in `flux-system`; its **`.spec.sync`** is the root Git (or OCI) path for your fleet layout — the same `clusters/my-cluster` idea as before, without `flux bootstrap`.
+
+1. **Install the operator** (Helm is typical; see [Flux Operator installation](https://fluxoperator.dev/docs/installation/) for current commands):
 
 ```bash
-flux bootstrap github \
-  --owner=your-username \
-  --repository=homelab-infra \
-  --branch=main \
-  --path=clusters/my-cluster
+helm install flux-operator oci://ghcr.io/controlplaneio-fluxcd/charts/flux-operator \
+  --namespace flux-system --create-namespace
 ```
 
-This creates the bootstrap kustomization that points to your `infrastructure/` and `apps/` directories.
+2. **Apply a `FluxInstance`** with Git sync pointing at your repo (private repos need a `git-credentials` secret and `pullSecret`). The operator will create the root source and Kustomization for that path:
 
-**Flux v2 Gotchas:**
-- **Namespace changes** — In v2, Flux components run in `flux-system` by default. Some older guides reference `flux` namespace.
-- **Kustomize controller** — The controller now handles kustomizations natively; you don't need separate `kustomize` CLI workflows.
-- **GitHub token scope** — The bootstrap command needs a token with `repo` and `workflow` permissions. Personal Access Tokens work, but GitHub Apps are recommended for production.
+```yaml
+apiVersion: fluxcd.controlplane.io/v1
+kind: FluxInstance
+metadata:
+  name: flux
+  namespace: flux-system
+spec:
+  distribution:
+    version: "2.x"
+    registry: ghcr.io/fluxcd
+  components:
+    - source-controller
+    - kustomize-controller
+    - helm-controller
+    - notification-controller
+  cluster:
+    type: kubernetes
+    size: small
+  sync:
+    kind: GitRepository
+    url: https://github.com/your-username/homelab-infra.git
+    ref: refs/heads/main
+    path: clusters/my-cluster
+    # pullSecret: git-credentials  # if the repo is private
+```
+
+If you already have an older **CLI bootstrap** install, you do **not** need to rebuild the cluster — use the [migration guide](https://fluxoperator.dev/docs/guides/migration/) to move to `FluxInstance`.
+
+**Flux / GitOps gotchas:**
+- **Namespace** — Flux components and the root objects the operator creates live in `flux-system` by default. Some older posts use a `flux` namespace; match your manifests to what the operator actually created.
+- **Kustomize** — Reconciliation is controller-side; you do not need a separate `kustomize` CLI loop for Flux to apply.
+- **Git credentials** — Use a Kubernetes Secret referenced by `pullSecret` for private Git; prefer narrow-scoped credentials and [Flux docs on Git auth](https://fluxcd.io/flux/components/source/gitrepositories/) for provider-specific options.
 - **Path separators** — Use forward slashes even on Windows; Flux paths are Git repository paths, not filesystem paths.
 - **OCI chart sources** — Flux 2.8+ uses `source.toolkit.fluxcd.io/v1` for GitRepository/HelmRepository/OCIRepository, but `helm.toolkit.fluxcd.io/v2` for HelmRelease. OCI-backed charts have two valid patterns: `HelmRepository` with `type: oci`, or `OCIRepository` directly. If one pattern fails, try the other.
 - **HelmRelease serverSideApply** — The `install.serverSideApply` field is a boolean, but `upgrade.serverSideApply` is an enum string (`"disabled"`). Mixing them incorrectly causes validation errors. Use:
@@ -292,7 +319,7 @@ This creates the bootstrap kustomization that points to your `infrastructure/` a
 
 ```
 homelab-infra/
-├── clusters/           # Flux bootstrap
+├── clusters/           # Cluster root (path referenced by FluxInstance .spec.sync)
 ├── infrastructure/
 │   ├── controllers/    # Traefik, Prometheus, etc.
 │   └── configs/        # Routes, monitoring, alerts

--- a/content/blog/homelab-flux-gitops-journey.md
+++ b/content/blog/homelab-flux-gitops-journey.md
@@ -45,28 +45,42 @@ The cluster went through four scheduling strategies:
 
 **Current rule**: Apps on workers. Monitoring on control plane. Documented exceptions in HelmRelease comments.
 
-### Helm Upgrades: The SSA Trap
+### Helm upgrades when charts drop resources
 
-Flux HelmRelease upgrades failed with:
+A concrete example: the OpenTelemetry operator chart upgrade (0.109 → 0.110) removed `kube-rbac-proxy`, which changed Service port layouts. Helm left stale listening paths behind, and reconciling produced confusing failures until the rendered chart and cluster state agreed.
 
-```
-invalid operation: cannot use force conflicts and force replace together
-```
-
-Turns out `install.serverSideApply` is a boolean (`false`), but `upgrade.serverSideApply` is an enum string (`"disabled"`). Same field name, different types.
+**What fixed it:** Read the chart changelog before bumping versions; pin if you are unsure. For day-to-day HelmReleases, use **`spec.install.strategy`** and **`spec.upgrade.strategy`** with **`name: RetryOnFailure`** (and a **`retryInterval`**) so failed applies retry without uninstalling the release. When a chart **stops owning** objects it used to manage (sidecars, old Services), set **`spec.upgrade.force: true`** on that upgrade so Helm can replace conflicting resources — then drop `force` again once the release is healthy.
 
 ```yaml
+apiVersion: helm.toolkit.fluxcd.io/v2
+kind: HelmRelease
+metadata:
+  name: example-operator
+  namespace: observability
 spec:
+  interval: 30m
+  chart:
+    spec:
+      chart: opentelemetry-operator
+      version: "0.109.x"
+      sourceRef:
+        kind: HelmRepository
+        name: open-telemetry
+      interval: 10m
   install:
-    serverSideApply: false   # boolean
+    timeout: 10m
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
   upgrade:
-    serverSideApply: disabled  # enum string
+    timeout: 10m
     force: true
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
 ```
 
-The OpenTelemetry operator upgrade (0.109 → 0.110) removed `kube-rbac-proxy`, changing Service port layouts. Three-way merge created duplicate `metrics` ports. Fixed by pinning the version and using `force: true` + `serverSideApply: disabled`.
-
-**Lesson**: Check chart changelogs for breaking infrastructure changes. Stay one version behind if unsure.
+**Lesson:** Treat chart upgrades that remove workloads or change discovery ports as infrastructure changes, not just a semver bump.
 
 ### Synology + Traefik = Special Handling
 
@@ -179,10 +193,18 @@ Flux has a built-in web UI (provided by the flux-operator) that shows the status
 - **Error visibility** — Quickly spot what's failing and why
 - **History & events** — See recent reconciliation attempts and outcomes
 
-**The enabling change:** Add these values to your `flux-instance` HelmRelease:
+**The enabling change:** On the `helm.toolkit.fluxcd.io/v2` HelmRelease that installs the flux-instance chart, use **`RetryOnFailure`** for install and upgrade, then set Web UI values:
 
 ```yaml
 spec:
+  install:
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
+  upgrade:
+    strategy:
+      name: RetryOnFailure
+      retryInterval: 5m
   values:
     instance:
       web:
@@ -241,7 +263,7 @@ When I ask "why is Immich down," it knows to check storage class first, then nod
 **Skill contents include:**
 - **Cluster hygiene** — Detecting mixed Endpoints + EndpointSlice issues, orphaned services, hardcoded LAN IPs
 - **Flux reconciliation** — Proper sequence for GitRepository → Kustomization → HelmRelease
-- **HelmRelease patterns** — `upgrade.force` + `serverSideApply` interactions, stuck kustomization recovery
+- **HelmRelease patterns** — `RetryOnFailure` install/upgrade strategies, narrow use of `upgrade.force` when charts drop resources, stuck kustomization recovery
 - **Secret management** — SOPS file structure, secret synchronization, validation workflows
 
 The **ce:compound** pattern (referenced from [Compound Engineering](https://every.to/guides/compound-engineering)) is a structured approach to documentation — researching problems, assembling solutions, writing them down, and validating that they work. Each documented solution makes the next one faster. This pattern applies to any project, not just homelabs.
@@ -304,15 +326,8 @@ If you already have an older **CLI bootstrap** install, you do **not** need to r
 - **Kustomize** — Reconciliation is controller-side; you do not need a separate `kustomize` CLI loop for Flux to apply.
 - **Git credentials** — Use a Kubernetes Secret referenced by `pullSecret` for private Git; prefer narrow-scoped credentials and [Flux docs on Git auth](https://fluxcd.io/flux/components/source/gitrepositories/) for provider-specific options.
 - **Path separators** — Use forward slashes even on Windows; Flux paths are Git repository paths, not filesystem paths.
-- **OCI chart sources** — Flux 2.8+ uses `source.toolkit.fluxcd.io/v1` for GitRepository/HelmRepository/OCIRepository, but `helm.toolkit.fluxcd.io/v2` for HelmRelease. OCI-backed charts have two valid patterns: `HelmRepository` with `type: oci`, or `OCIRepository` directly. If one pattern fails, try the other.
-- **HelmRelease serverSideApply** — The `install.serverSideApply` field is a boolean, but `upgrade.serverSideApply` is an enum string (`"disabled"`). Mixing them incorrectly causes validation errors. Use:
-  ```yaml
-  install:
-    serverSideApply: false
-  upgrade:
-    serverSideApply: disabled
-    force: true
-  ```
+- **OCI chart sources** — Flux uses `source.toolkit.fluxcd.io/v1` for GitRepository/HelmRepository/OCIRepository and `helm.toolkit.fluxcd.io/v2` for HelmRelease. OCI-backed charts have two valid patterns: `HelmRepository` with `type: oci`, or `OCIRepository` directly. If one pattern fails, try the other.
+- **HelmRelease strategies** — Prefer **`spec.install.strategy`** and **`spec.upgrade.strategy`** with **`name: RetryOnFailure`** (and **`retryInterval`**). Use **`spec.upgrade.force: true`** only when a chart stops owning objects it previously created, then remove it once the release is clean.
 - **Stuck kustomizations** — If a `HelmRelease` health check fails, downstream kustomizations with `spec.dependsOn` will wait indefinitely. Check `kubectl describe kustomization <name> -n flux-system` for `HealthCheckFailed`. High `helm-controller` CPU often indicates a failing Helm release in a retry loop.
 
 ### 3. Structure Your Repo


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Updates the homelab Flux post to match current Flux project guidance: install via the Flux Operator and a `FluxInstance` with Git sync, with links to installation and migration docs. Removes the `flux bootstrap github` walkthrough while keeping practical gotchas (OCI sources, stuck kustomizations).

HelmRelease guidance now follows canonical `helm.toolkit.fluxcd.io/v2` patterns: `RetryOnFailure` install/upgrade strategies with `retryInterval`, and short-lived `upgrade.force` only when charts stop owning prior resources—no serverSideApply-focused narrative. Flux Web UI snippet includes the same strategy blocks on the wrapping HelmRelease.

No cluster changes—editorial accuracy only for readers following the post.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-6e07f590-4c11-4e1e-923a-30dbb7d7349e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-6e07f590-4c11-4e1e-923a-30dbb7d7349e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

