### PR TITLE
Link resume location to Boston map

### DIFF
--- a/app/components/resume/ResumeProseA.vue
+++ b/app/components/resume/ResumeProseA.vue
@@ -17,6 +17,7 @@ const socialIconMap: Record<string, string> = {
   'mailto:': 'i-mdi-email',
   'geo:': 'i-mdi-map-marker',
   'maps.google.com': 'i-mdi-map-marker',
+  'nuxt-maplibre/demo/map/markers': 'i-mdi-map-marker',
   'marr.github.io': 'i-mdi-web',
 }
 

--- a/content/resume.md
+++ b/content/resume.md
@@ -13,7 +13,7 @@ Also available as [**PDF**](/resume.pdf){external}.
 # David Marr's CV
 
 - [dave.marr@gmail.com](mailto:dave.marr@gmail.com)
-- Boston, MA
+- [Boston, MA](https://marr.github.io/nuxt-maplibre/demo/map/markers/#marker=42.35900,-71.05789){external}
 - [marr.github.io](https://marr.github.io/)
 - [marr](https://github.com/marr)
 - [davidmarr](https://linkedin.com/in/davidmarr)

--- a/public/resume-ats.pdf
+++ b/public/resume-ats.pdf
@@ -2271,8 +2271,8 @@ endobj
   /Title (David Marr - CV)
   /Author (David Marr)
   /Creator (Typst 0.14.2)
-  /ModDate (D:20260512000000Z)
-  /CreationDate (D:20260512000000Z)
+  /ModDate (D:20260513000000Z)
+  /CreationDate (D:20260513000000Z)
 >>
 endobj
 
@@ -2283,7 +2283,7 @@ endobj
   /Subtype /XML
 >>
 stream
-<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">David Marr - CV</rdf:li></rdf:Alt></dc:title><dc:creator><rdf:Seq><rdf:li>David Marr</rdf:li></rdf:Seq></dc:creator><xmp:CreatorTool>Typst 0.14.2</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-05-12T00:00:00Z</xmp:ModifyDate><xmp:CreateDate>2026-05-12T00:00:00Z</xmp:CreateDate><xmpTPg:NPages>2</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>Wq9kMdhnBTGmGYf6iytXvQ==</xmpMM:InstanceID><xmpMM:DocumentID>xw9+TWDyQk1pp0+xvGlaqg==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">David Marr - CV</rdf:li></rdf:Alt></dc:title><dc:creator><rdf:Seq><rdf:li>David Marr</rdf:li></rdf:Seq></dc:creator><xmp:CreatorTool>Typst 0.14.2</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-05-13T00:00:00Z</xmp:ModifyDate><xmp:CreateDate>2026-05-13T00:00:00Z</xmp:CreateDate><xmpTPg:NPages>2</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>AVgr8NN1qqEN0k1OdID2FA==</xmpMM:InstanceID><xmpMM:DocumentID>xw9+TWDyQk1pp0+xvGlaqg==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
 endstream
 endobj
 
@@ -2507,7 +2507,7 @@ trailer
   /Size 195
   /Root 194 0 R
   /Info 192 0 R
-  /ID [(xw9+TWDyQk1pp0+xvGlaqg==) (Wq9kMdhnBTGmGYf6iytXvQ==)]
+  /ID [(xw9+TWDyQk1pp0+xvGlaqg==) (AVgr8NN1qqEN0k1OdID2FA==)]
 >>
 startxref
 47085

--- a/public/resume.pdf
+++ b/public/resume.pdf
@@ -2594,8 +2594,8 @@ endobj
   /Title (David Marr - CV)
   /Author (David Marr)
   /Creator (Typst 0.14.2)
-  /ModDate (D:20260512000000Z)
-  /CreationDate (D:20260512000000Z)
+  /ModDate (D:20260513000000Z)
+  /CreationDate (D:20260513000000Z)
 >>
 endobj
 
@@ -2606,7 +2606,7 @@ endobj
   /Subtype /XML
 >>
 stream
-<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">David Marr - CV</rdf:li></rdf:Alt></dc:title><dc:creator><rdf:Seq><rdf:li>David Marr</rdf:li></rdf:Seq></dc:creator><xmp:CreatorTool>Typst 0.14.2</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-05-12T00:00:00Z</xmp:ModifyDate><xmp:CreateDate>2026-05-12T00:00:00Z</xmp:CreateDate><xmpTPg:NPages>2</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>Q+UIBP59Ey0y3urZBhUfUg==</xmpMM:InstanceID><xmpMM:DocumentID>xw9+TWDyQk1pp0+xvGlaqg==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
+<?xpacket begin="﻿" id="W5M0MpCehiHzreSzNTczkc9d"?><x:xmpmeta xmlns:x="adobe:ns:meta/" x:xmptk="xmp-writer"><rdf:RDF xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"><rdf:Description rdf:about="" xmlns:dc="http://purl.org/dc/elements/1.1/"  xmlns:xmp="http://ns.adobe.com/xap/1.0/"  xmlns:xmpMM="http://ns.adobe.com/xap/1.0/mm/"  xmlns:xmpTPg="http://ns.adobe.com/xap/1.0/t/pg/"  xmlns:pdf="http://ns.adobe.com/pdf/1.3/" ><dc:title><rdf:Alt><rdf:li xml:lang="x-default">David Marr - CV</rdf:li></rdf:Alt></dc:title><dc:creator><rdf:Seq><rdf:li>David Marr</rdf:li></rdf:Seq></dc:creator><xmp:CreatorTool>Typst 0.14.2</xmp:CreatorTool><dc:language><rdf:Bag><rdf:li>en</rdf:li></rdf:Bag></dc:language><xmp:ModifyDate>2026-05-13T00:00:00Z</xmp:ModifyDate><xmp:CreateDate>2026-05-13T00:00:00Z</xmp:CreateDate><xmpTPg:NPages>2</xmpTPg:NPages><dc:format>application/pdf</dc:format><xmpMM:InstanceID>0FsKYEtHc8VV6ZSJCh82sg==</xmpMM:InstanceID><xmpMM:DocumentID>xw9+TWDyQk1pp0+xvGlaqg==</xmpMM:DocumentID><xmpMM:RenditionClass>proof</xmpMM:RenditionClass><pdf:PDFVersion>1.7</pdf:PDFVersion></rdf:Description></rdf:RDF></x:xmpmeta><?xpacket end="r"?>
 endstream
 endobj
 
@@ -2848,7 +2848,7 @@ trailer
   /Size 213
   /Root 212 0 R
   /Info 210 0 R
-  /ID [(xw9+TWDyQk1pp0+xvGlaqg==) (Q+UIBP59Ey0y3urZBhUfUg==)]
+  /ID [(xw9+TWDyQk1pp0+xvGlaqg==) (0FsKYEtHc8VV6ZSJCh82sg==)]
 >>
 startxref
 53965

--- a/scripts/harmonize_resume_headings.py
+++ b/scripts/harmonize_resume_headings.py
@@ -17,6 +17,8 @@ from __future__ import annotations
 import re
 import sys
 
+BOSTON_MAP_URL = "https://marr.github.io/nuxt-maplibre/demo/map/markers/#marker=42.35900,-71.05789"
+
 
 def harmonize(md: str) -> str:
     lines = md.splitlines()
@@ -32,6 +34,8 @@ def harmonize(md: str) -> str:
             out.append("## Skills")
         elif line.startswith("## **"):
             out.append("#" + line)
+        elif line == "- Boston, MA":
+            out.append(f"- [Boston, MA]({BOSTON_MAP_URL}){{external}}")
         else:
             out.append(line)
     trailing = md.endswith("\n")


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- Link the web resume contact location to the Boston map marker URL.
- Keep the generated resume content stable by applying the link during CV markdown harmonization.
- Preserve the location affordance by using the map-marker icon for the map URL.

## Testing
- `pnpm cv:render && pnpm build`
- `npx nuxi typecheck`
- Browser-tested `/resume` link hover/click navigation.

[resume_boston_marker_link_latest.mp4](https://cursor.com/agents/bc-e4e5a18a-6eeb-4d60-b108-347671d28ce9/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fresume_boston_marker_link_latest.mp4)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e4e5a18a-6eeb-4d60-b108-347671d28ce9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e4e5a18a-6eeb-4d60-b108-347671d28ce9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

