### PR TITLE
Load homepage Watching repos from Redis Iris

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,7 @@
+# Redis Iris (Context Surfaces) — optional; enables the homepage "Watching" section at build time.
+# Create an agent key in the Redis Cloud Context Retriever console for your GitHub surface.
+MCP_AGENT_KEY=
+
+# Optional overrides (defaults match the context-surfaces Python SDK)
+# CTX_MCP_URL=https://gcp-us-east4.context-surfaces.redis.io/mcp
+# IRIS_WATCHED_REPOS_TOOL=filter_repository_by_watched

--- a/.github/workflows/studio.yml
+++ b/.github/workflows/studio.yml
@@ -72,6 +72,10 @@ jobs:
           bash scripts/render-cv.sh
 
       - name: Generate
+        env:
+          MCP_AGENT_KEY: ${{ secrets.MCP_AGENT_KEY }}
+          IRIS_WATCHED_REPOS_TOOL: ${{ secrets.IRIS_WATCHED_REPOS_TOOL }}
+          CTX_MCP_URL: ${{ secrets.CTX_MCP_URL }}
         run: npx nuxi build --preset github_pages
 
       # Deployment job

--- a/.impeccable.md
+++ b/.impeccable.md
@@ -44,6 +44,7 @@ Suggested **information architecture** (see `content/index.md`):
 | **Open source** | Repos you maintain—proof of shipping. |
 | **Staples** | Long-running tools you reach for again and again (not “news”). |
 | **Exploring** | Active curiosity—frameworks, infra, ideas on the workbench. |
+| **Watching** | GitHub repos you follow—optional, from Redis Iris when `MCP_AGENT_KEY` is set at build. |
 | **Archive** | Demos or tools you no longer foreground; kept for reference. |
 
 Keep descriptions factual and short; avoid hype. Rebalance cards between **Exploring** and **Archive** as interests change.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,3 +27,4 @@ This is a Nuxt 4 personal portfolio/blog site (`@dmarr/cv`). It is a single appl
 - The CV/resume rendering (`pnpm cv:render`) requires Python 3 + `rendercv[full]==2.8` but pre-built artifacts (`public/resume.pdf`, `content/resume.md`) are already committed, so this is only needed when editing the CV YAML.
 - `@nuxt/content` v3 uses an embedded SQLite database (`better-sqlite3`) — no external database setup is needed.
 - No Docker, external APIs, or microservices are required.
+- **Redis Iris (optional):** Set `MCP_AGENT_KEY` (and optionally `IRIS_WATCHED_REPOS_TOOL`, `CTX_MCP_URL`) to populate the homepage **Watching** section from [Redis Iris](https://redis.io/iris/) Context Retriever MCP tools at build/SSR time. Without credentials the section is omitted. See `.env.example`.

--- a/app/components/content/WatchedReposGrid.vue
+++ b/app/components/content/WatchedReposGrid.vue
@@ -1,0 +1,67 @@
+<template>
+  <section
+    v-if="showSection"
+    class="py-10"
+  >
+    <header class="mb-8 max-w-prose border-l-2 border-primary/40 pl-4">
+      <h2 class="text-2xl font-bold tracking-tight text-default">
+        {{ title }}
+      </h2>
+      <p
+        v-if="description"
+        class="mt-2 text-sm leading-relaxed text-muted"
+      >
+        {{ description }}
+      </p>
+    </header>
+
+    <p
+      v-if="error"
+      class="mb-4 text-sm text-muted"
+    >
+      Watched repos are temporarily unavailable.
+    </p>
+
+    <div class="home-stagger-grid grid gap-4 sm:grid-cols-2">
+      <ProjectCard
+        v-for="repo in repos"
+        :key="repo.url"
+        :title="repo.title"
+        :url="repo.url"
+        :description="repo.description"
+        :icon="repo.icon"
+        :tags="repo.tags"
+      />
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import ProjectCard from '~/components/content/ProjectCard.vue'
+
+interface WatchedRepo {
+  title: string
+  url: string
+  description?: string
+  tags?: string[]
+  icon?: string
+}
+
+interface Props {
+  title?: string
+  description?: string
+}
+
+const {
+  title = 'Watching',
+  description = 'GitHub repos I follow—synced from Redis Iris context at build time.',
+} = defineProps<Props>()
+
+const { data } = await useFetch('/api/watched-repos')
+
+const repos = computed(() => data.value?.repos ?? [])
+const error = computed(() => data.value?.error)
+const showSection = computed(
+  () => data.value?.enabled === true && repos.value.length > 0,
+)
+</script>

--- a/content/index.md
+++ b/content/index.md
@@ -263,6 +263,13 @@ description: On the workbench right now—frameworks, infra, and ideas worth try
   :::
 ::
 
+::watched-repos-grid
+---
+title: Watching
+description: GitHub repos I follow—loaded from Redis Iris (Context Retriever) when MCP credentials are configured at build time.
+---
+::
+
 ::project-grid
 ---
 title: Archive

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -5,12 +5,10 @@ export default defineNuxtConfig({
   modules: ["@nuxt/ui", "@nuxt/content"],
   devtools: { enabled: true },
   runtimeConfig: {
-    /** Redis Iris Context Surfaces agent key (server-only). */
-    mcpAgentKey: process.env.MCP_AGENT_KEY || "",
-    /** Optional override for Context Surfaces MCP endpoint. */
-    ctxMcpUrl: process.env.CTX_MCP_URL || "",
-    /** Optional explicit MCP tool name for watched repositories. */
-    irisWatchedReposTool: process.env.IRIS_WATCHED_REPOS_TOOL || "",
+    /** Redis Iris Context Surfaces agent key (server-only). Also reads MCP_AGENT_KEY at runtime. */
+    mcpAgentKey: "",
+    ctxMcpUrl: "",
+    irisWatchedReposTool: "",
   },
   app: {
     head: {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -4,6 +4,14 @@ import tailwindcss from "@tailwindcss/vite";
 export default defineNuxtConfig({
   modules: ["@nuxt/ui", "@nuxt/content"],
   devtools: { enabled: true },
+  runtimeConfig: {
+    /** Redis Iris Context Surfaces agent key (server-only). */
+    mcpAgentKey: process.env.MCP_AGENT_KEY || "",
+    /** Optional override for Context Surfaces MCP endpoint. */
+    ctxMcpUrl: process.env.CTX_MCP_URL || "",
+    /** Optional explicit MCP tool name for watched repositories. */
+    irisWatchedReposTool: process.env.IRIS_WATCHED_REPOS_TOOL || "",
+  },
   app: {
     head: {
       link: [

--- a/server/api/watched-repos.get.ts
+++ b/server/api/watched-repos.get.ts
@@ -4,6 +4,13 @@ import {
   type WatchedRepo,
 } from '../utils/iris'
 
+function env(name: string): string {
+  const envRecord = (globalThis as { process?: { env?: Record<string, string | undefined> } })
+    .process?.env
+  const value = envRecord?.[name]
+  return typeof value === 'string' ? value : ''
+}
+
 export default defineEventHandler(async (event): Promise<{
   enabled: boolean
   repos: WatchedRepo[]
@@ -12,9 +19,9 @@ export default defineEventHandler(async (event): Promise<{
 }> => {
   const config = useRuntimeConfig(event)
   const irisConfig = {
-    mcpAgentKey: config.mcpAgentKey,
-    ctxMcpUrl: config.ctxMcpUrl,
-    irisWatchedReposTool: config.irisWatchedReposTool,
+    mcpAgentKey: config.mcpAgentKey || env('MCP_AGENT_KEY'),
+    ctxMcpUrl: config.ctxMcpUrl || env('CTX_MCP_URL'),
+    irisWatchedReposTool: config.irisWatchedReposTool || env('IRIS_WATCHED_REPOS_TOOL'),
   }
 
   if (!isIrisConfigured(irisConfig)) {

--- a/server/api/watched-repos.get.ts
+++ b/server/api/watched-repos.get.ts
@@ -1,0 +1,33 @@
+import {
+  fetchWatchedReposFromIris,
+  isIrisConfigured,
+  type WatchedRepo,
+} from '../utils/iris'
+
+export default defineEventHandler(async (event): Promise<{
+  enabled: boolean
+  repos: WatchedRepo[]
+  source?: 'iris'
+  error?: string
+}> => {
+  const config = useRuntimeConfig(event)
+  const irisConfig = {
+    mcpAgentKey: config.mcpAgentKey,
+    ctxMcpUrl: config.ctxMcpUrl,
+    irisWatchedReposTool: config.irisWatchedReposTool,
+  }
+
+  if (!isIrisConfigured(irisConfig)) {
+    return { enabled: false, repos: [] }
+  }
+
+  try {
+    const repos = await fetchWatchedReposFromIris(irisConfig)
+    return { enabled: true, repos, source: 'iris' }
+  }
+  catch (error) {
+    const message = error instanceof Error ? error.message : 'Failed to load watched repos'
+    console.error('[watched-repos]', message)
+    return { enabled: true, repos: [], source: 'iris', error: message }
+  }
+})

--- a/server/utils/iris.ts
+++ b/server/utils/iris.ts
@@ -1,0 +1,295 @@
+/**
+ * Redis Iris (Context Surfaces) MCP client for watched GitHub repositories.
+ * @see https://redis.io/iris/
+ * @see https://redis.io/docs/latest/develop/ai/context-engine/context-retriever/
+ */
+
+const DEFAULT_MCP_URL = 'https://gcp-us-east4.context-surfaces.redis.io/mcp'
+
+export interface IrisConfig {
+  mcpAgentKey?: string
+  ctxMcpUrl?: string
+  irisWatchedReposTool?: string
+}
+
+export interface WatchedRepo {
+  title: string
+  url: string
+  description?: string
+  tags?: string[]
+  icon?: string
+}
+
+type McpJson = Record<string, unknown>
+
+function getMcpUrl(config: IrisConfig): string {
+  return config.ctxMcpUrl?.trim() || DEFAULT_MCP_URL
+}
+
+function getAgentKey(config: IrisConfig): string | undefined {
+  const key = config.mcpAgentKey?.trim()
+  return key || undefined
+}
+
+function getWatchedReposToolName(config: IrisConfig): string | undefined {
+  const name = config.irisWatchedReposTool?.trim()
+  return name || undefined
+}
+
+async function mcpRequest<T = unknown>(
+  config: IrisConfig,
+  method: string,
+  params: Record<string, unknown> = {},
+): Promise<T> {
+  const agentKey = getAgentKey(config)
+  if (!agentKey) {
+    throw new Error('MCP_AGENT_KEY is not configured')
+  }
+
+  const response = await fetch(getMcpUrl(config), {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-API-Key': agentKey,
+    },
+    body: JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      method,
+      params,
+    }),
+  })
+
+  if (!response.ok) {
+    throw new Error(`Iris MCP HTTP ${response.status}: ${response.statusText}`)
+  }
+
+  const data = (await response.json()) as McpJson
+  if (data.error) {
+    throw new Error(`Iris MCP error: ${JSON.stringify(data.error)}`)
+  }
+
+  return data.result as T
+}
+
+export async function listIrisTools(
+  config: IrisConfig,
+): Promise<Array<{ name: string, description?: string }>> {
+  const result = await mcpRequest<{ tools?: Array<{ name: string, description?: string }> }>(
+    config,
+    'tools/list',
+  )
+  return result.tools ?? []
+}
+
+function pickWatchedReposTool(
+  config: IrisConfig,
+  tools: Array<{ name: string, description?: string }>,
+): string | undefined {
+  const explicit = getWatchedReposToolName(config)
+  if (explicit) {
+    return tools.some(t => t.name === explicit) ? explicit : explicit
+  }
+
+  const patterns = [
+    /filter_.*repositor.*watch/i,
+    /filter_.*watch.*repositor/i,
+    /list_.*watch.*repositor/i,
+    /list_.*repositor.*watch/i,
+    /filter_repositor/i,
+    /search_.*repositor/i,
+  ]
+
+  for (const pattern of patterns) {
+    const match = tools.find(t => pattern.test(t.name))
+    if (match) return match.name
+  }
+
+  return tools.find(t => /repositor/i.test(t.name))?.name
+}
+
+function extractTextPayload(result: unknown): string | undefined {
+  if (!result || typeof result !== 'object') return undefined
+  const record = result as McpJson
+  const content = record.content
+  if (!Array.isArray(content)) return undefined
+  const textBlock = content.find(
+    (item): item is { type: string, text: string } =>
+      typeof item === 'object'
+      && item !== null
+      && (item as McpJson).type === 'text'
+      && typeof (item as McpJson).text === 'string',
+  )
+  return textBlock?.text
+}
+
+function parseToolPayload(result: unknown): unknown {
+  if (!result || typeof result !== 'object') return result
+  const record = result as McpJson
+
+  const text = extractTextPayload(result)
+  if (text) {
+    try {
+      return JSON.parse(text)
+    }
+    catch {
+      return { raw_text: text }
+    }
+  }
+
+  if (typeof record.raw_text === 'string') {
+    try {
+      return JSON.parse(record.raw_text)
+    }
+    catch {
+      return { raw_text: record.raw_text }
+    }
+  }
+
+  return result
+}
+
+function collectRecords(payload: unknown): McpJson[] {
+  if (!payload) return []
+  if (Array.isArray(payload)) {
+    return payload.filter((item): item is McpJson => typeof item === 'object' && item !== null)
+  }
+  if (typeof payload !== 'object') return []
+
+  const record = payload as McpJson
+  const buckets = ['results', 'records', 'items', 'repositories', 'data']
+  for (const key of buckets) {
+    const value = record[key]
+    if (Array.isArray(value)) {
+      return value.filter((item): item is McpJson => typeof item === 'object' && item !== null)
+    }
+  }
+
+  return [record]
+}
+
+function stringField(record: McpJson, keys: string[]): string | undefined {
+  for (const key of keys) {
+    const value = record[key]
+    if (typeof value === 'string' && value.trim()) return value.trim()
+  }
+  return undefined
+}
+
+function buildRepoUrl(record: McpJson): string | undefined {
+  const direct = stringField(record, ['html_url', 'url', 'repo_url', 'repository_url'])
+  if (direct) return direct
+
+  const fullName = stringField(record, ['full_name', 'repo_full_name', 'repository_full_name'])
+  if (fullName) return `https://github.com/${fullName}`
+
+  const owner = stringField(record, ['owner', 'owner_login', 'org'])
+  const name = stringField(record, ['name', 'repo_name', 'repository_name', 'title'])
+  if (owner && name) return `https://github.com/${owner}/${name}`
+
+  return undefined
+}
+
+function languageIcon(language?: string): string | undefined {
+  if (!language) return 'i-mdi-github'
+  const slug = language.toLowerCase().replace(/[^a-z0-9+#]/g, '')
+  const map: Record<string, string> = {
+    typescript: 'i-logos-typescript-icon',
+    javascript: 'i-simple-icons-javascript',
+    vue: 'i-logos-vue',
+    python: 'i-logos-python',
+    go: 'i-logos-go',
+    rust: 'i-logos-rust',
+    java: 'i-logos-java',
+    kotlin: 'i-logos-kotlin-icon',
+    ruby: 'i-logos-ruby',
+    nuxt: 'i-logos-nuxt-icon',
+  }
+  return map[slug] ?? 'i-mdi-github'
+}
+
+function mapRecordToWatchedRepo(record: McpJson): WatchedRepo | undefined {
+  const url = buildRepoUrl(record)
+  if (!url) return undefined
+
+  const title
+    = stringField(record, ['full_name', 'name', 'repo_name', 'repository_name', 'title'])
+      ?? url.replace(/^https:\/\/github\.com\//, '')
+
+  const description = stringField(record, [
+    'description',
+    'summary',
+    'repo_description',
+  ])
+
+  const language = stringField(record, ['language', 'primary_language'])
+  const topics = record.topics
+  const tags = [
+    ...(language ? [language] : []),
+    ...(Array.isArray(topics)
+      ? topics.filter((t): t is string => typeof t === 'string').slice(0, 2)
+      : []),
+  ]
+
+  return {
+    title,
+    url,
+    description,
+    tags: tags.length ? tags : undefined,
+    icon: languageIcon(language),
+  }
+}
+
+function buildToolArguments(toolName: string): Record<string, unknown> {
+  const args: Record<string, unknown> = { limit: 24 }
+
+  if (/watch/i.test(toolName)) {
+    args.watched = true
+    args.is_watched = true
+  }
+
+  if (/filter_/i.test(toolName)) {
+    args.field = 'watched'
+    args.value = true
+  }
+
+  return args
+}
+
+export async function fetchWatchedReposFromIris(config: IrisConfig): Promise<WatchedRepo[]> {
+  const tools = await listIrisTools(config)
+  const toolName = pickWatchedReposTool(config, tools)
+  if (!toolName) {
+    throw new Error(
+      'No repository tool found on Iris context surface. Set IRIS_WATCHED_REPOS_TOOL.',
+    )
+  }
+
+  const raw = await mcpRequest(
+    config,
+    'tools/call',
+    {
+      name: toolName,
+      arguments: buildToolArguments(toolName),
+    },
+  )
+
+  const parsed = parseToolPayload(raw)
+  const records = collectRecords(parsed)
+
+  const seen = new Set<string>()
+  const repos: WatchedRepo[] = []
+
+  for (const record of records) {
+    const repo = mapRecordToWatchedRepo(record)
+    if (!repo || seen.has(repo.url)) continue
+    seen.add(repo.url)
+    repos.push(repo)
+  }
+
+  return repos.slice(0, 24)
+}
+
+export function isIrisConfigured(config: IrisConfig): boolean {
+  return Boolean(getAgentKey(config))
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a **Watching** section on the homepage that loads GitHub watched repositories from [Redis Iris](https://redis.io/iris/) (Context Retriever / Context Surfaces MCP) at build and SSR time.

When `MCP_AGENT_KEY` is set, the site:

1. Calls the Context Surfaces MCP endpoint (`tools/list`, then `tools/call`)
2. Auto-discovers a repository watch-list tool (or uses `IRIS_WATCHED_REPOS_TOOL`)
3. Maps structured results to existing `ProjectCard` components

Without credentials, the section is omitted so GitHub Pages builds stay unchanged.

## Setup

Add repository secrets (or local `.env` from `.env.example`):

- `MCP_AGENT_KEY` — agent key from your Redis Cloud Context Retriever service
- `IRIS_WATCHED_REPOS_TOOL` (optional) — explicit MCP tool name if auto-discovery does not match your surface schema
- `CTX_MCP_URL` (optional) — defaults to the context-surfaces SDK production MCP URL

## Testing

- `npx nuxi typecheck`
- `npx nuxi build --preset github_pages`

The Watching grid only appears when Iris returns at least one repo.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-7704df4a-b363-4ff1-a24f-9409de17e28c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-7704df4a-b363-4ff1-a24f-9409de17e28c"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

