### PR TITLE
docs: Slack-safe table formatting for agent responses

### DIFF
--- a/.agents/skills/emil-design-eng/SKILL.md
+++ b/.agents/skills/emil-design-eng/SKILL.md
@@ -59,6 +59,8 @@ After: scale(0.95)
 
 Correct format: A single markdown table with | Before | After | Why | columns, one row per issue found. The "Why" column briefly explains the reasoning.
 
+**Slack exception:** When the review will be read in Slack (Cloud Agent channel updates, pasted summaries), pipe tables will not render. Use structured bullets instead — one issue per bullet, `Before → After` inline, reason in parentheses — or an ASCII table inside a monospace code block. Keep the same Before/After/Why content; only change the wrapper format.
+
 ## The Animation Decision Framework
 
 Before writing any animation code, answer these questions in order:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -8,13 +8,23 @@ This is a Nuxt 4 personal portfolio/blog site (`@dmarr/cv`). It is a single appl
 
 ### Quick reference
 
-| Action | Command |
-|--------|---------|
-| Install deps | `pnpm install` |
-| Dev server | `pnpm dev` (serves at `http://localhost:3000`) |
-| Build | `pnpm build` |
-| Typecheck | `npx nuxi typecheck` |
-| Generate types | `npx nuxi prepare` |
+- **Install deps:** `pnpm install`
+- **Dev server:** `pnpm dev` (serves at `http://localhost:3000`)
+- **Build:** `pnpm build`
+- **Typecheck:** `npx nuxi typecheck`
+- **Generate types:** `npx nuxi prepare`
+
+### Slack communication
+
+When replying in Slack (including Cloud Agent updates mirrored to a channel), **do not use pipe-style markdown tables** (`| col | col |`). Slack mrkdwn renders them as plain text with literal pipes.
+
+For tabular data in Slack, use one of:
+
+1. **Structured bullets** — bold row labels, values inline (best for 2–4 columns).
+2. **Monospace code block** — ASCII-aligned columns inside a fenced block (best for wider grids).
+3. **GitHub / site links** — point to content where GFM tables render (blog posts, PRs).
+
+Blog and resume markdown tables on the site are fine; this rule applies only to Slack-delivered agent text.
 
 ### Notes
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Slack does not render pipe-style markdown tables in agent messages — they show up as literal `|` characters. This adds repo-level guidance so Cloud Agent updates posted to Slack stay readable.

## Changes

- **AGENTS.md:** Replace the quick-reference markdown table with a bullet list (which also renders cleanly in Slack). Add a **Slack communication** section describing safe alternatives for tabular data.
- **emil-design-eng skill:** Add a Slack exception to the required Before/After review format so UI reviews can use bullets or ASCII code blocks when delivered via Slack.

## Notes

Blog GFM tables on the site (e.g. homelab storage-class table) render correctly in the browser — this change targets Slack-delivered agent text only.
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://graphstrike.slack.com/archives/C0AN4A7HZ99/p1780237889509839?thread_ts=1780237889.509839&cid=C0AN4A7HZ99)

<div><a href="https://cursor.com/agents/bc-c60f8be9-ebc2-57bb-a590-fae6f919cfd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-c60f8be9-ebc2-57bb-a590-fae6f919cfd9"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

