### PR TITLE
fix(blog): refresh layout header on client-side post navigation

### DIFF
--- a/app/layouts/blog.vue
+++ b/app/layouts/blog.vue
@@ -1,9 +1,10 @@
 <script setup lang="ts">
-const route = useRoute();
-const { data: page } = await useAsyncData("blog-layout-" + route.path, () => {
-  return queryCollection("blog").path(route.path).first();
-});
-
+const contentPath = useContentPath();
+const { data: page } = await useAsyncData(
+  () => `blog-layout-${contentPath.value}`,
+  () => queryCollection("blog").path(contentPath.value).first(),
+  { watch: [contentPath] },
+);
 </script>
 
 <template>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes a bug where the blog post header (title, description, date) stayed stale when navigating between posts via in-article links.

On `/blog/knowledge-graph-obsidian-mcp`, clicking through from the homelab post would update the URL and article body, but the layout header still showed "Building a Homelab with Flux GitOps: Lessons from Three Months".

## Cause

`app/layouts/blog.vue` used a static `useAsyncData` key (`"blog-layout-" + route.path`) evaluated once at layout setup. Nuxt reuses the layout across post-to-post navigation, so the cached header data never refreshed.

## Fix

Use `useContentPath()` with a reactive `useAsyncData` key and `watch: [contentPath]`, matching the pattern already used in `app/pages/blog/[...slug].vue`.

## Verification

- Reproduced: homelab post → in-article link → knowledge graph post showed wrong H1
- Verified fix: header now updates to "Building a Knowledge Graph with Obsidian and MCP" on client-side navigation
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-af131da8-4463-431b-b4ee-9661677e4100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-af131da8-4463-431b-b4ee-9661677e4100"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

